### PR TITLE
Update name in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no" ?>
 <package format="1">
-  <name>Assembly4</name>
+  <name>Assembly 4.1</name>
   <description>This assembly workbench use lets you put FreeCAD parts (Part and Body) together inside a standard assembly container.</description>
   <version>0.50.18</version>
   <date>2025.03.11</date>


### PR DESCRIPTION
It is confusing in the Addon Manager's list of addons when there are multiple addons with the same displayed name -- this PR updates the displayed name for this fork to include the ".1" you've appended to the name of the addon. Note that you can feel free to change this to whatever else you want (the only restriction is that you can't have carriage returns or curly braces in the name).