### PR TITLE
Update icon path in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -9,11 +9,11 @@
 	<url type="repository" branch="main">https://github.com/leoheck/FreeCAD_Assembly4.1</url>
 	<url type="documentation">https://wiki.freecadweb.org/Assembly4_Workbench</url>
 	<url type="readme">https://github.com/leoheck/FreeCAD_Assembly4.1/blob/main/README.md</url>
+	<icon>freecad/Resources/icons/Assembly4.svg</icon>
 	<content>
 		<workbench>
 			<classname>Assembly4p1Workbench</classname>
 			<subdirectory>./freecad/Asm4p1/</subdirectory>
-			<icon>../Resources/icons/Assembly4.svg</icon>
 			<tag>assembly</tag>
 			<freecadmin>0.19.0</freecadmin>
 		</workbench>


### PR DESCRIPTION
Update `<icon>` path in `package.xml` so it's a top-level tag as recommended by the [Addon Metadata guide on the wiki](https://wiki.freecad.org/Package_Metadata#Required_child_tags). Icons can be defined by content item but it's easier to specify a single one for the whole package.